### PR TITLE
tasks - Use prettier API, not CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "node ./tasks/lint-contents.js",
     "fix": "node ./tasks/fix-contents && yarn format",
     "lint-js": "eslint './**/*.js'",
-    "format": "prettier --write '{README.md,{docs,src,tasks}/**/*.{json,js,md}}' && node ./tasks/build-schemas.js && node ./tasks/format-docs.js",
+    "format": "node ./tasks/build-schemas.js && node ./tasks/format-docs.js",
     "validate": "node ./tasks/validate-jsons.js",
     "deploy": "NODE_DEBUG=gh-pages node ./tasks/deploy.js"
   },

--- a/tasks/lib/format-docs.js
+++ b/tasks/lib/format-docs.js
@@ -48,9 +48,11 @@ const formatDocs = (srcDir, schemasDir) => {
       const schema = schemaMap[schemaId];
       const schemaOrderList = Object.keys(schema.properties);
       const sorted = sortDocProperties(doc, schemaOrderList);
+      const config = prettier.resolveConfig.sync(path);
       const formatted = prettier.format(
         `${JSON.stringify(sorted, null, 2)}\n`,
         {
+          ...config,
           parser: 'json'
         }
       );
@@ -69,7 +71,9 @@ const formatDocs = (srcDir, schemasDir) => {
   glob.sync(mdPattern).forEach(path => {
     try {
       const docString = readFileSync(path, 'utf8');
+      const config = prettier.resolveConfig.sync(path);
       const formatted = prettier.format(docString, {
+        ...config,
         parser: 'markdown'
       });
       const hasModified = formatted !== docString;


### PR DESCRIPTION
@Luzlum 
`git commit` 前に自動で走る `yarn format` で変更があった場合、
`git commit` は次のメッセージとともに中断します。

```
ℹ You might want to run `git add` to commit these formatted files.
WARN  Format task will exit with code 1 to run `git add`.
```

* `git commit` の前に自動で走る `yarn format` でファイルに変更があった場合は commit を中断する
  * 変更があったファイルを `git add` しなおすため
  * `yarn format` で prettier CLI ではなく API を利用する
    * https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath-options
